### PR TITLE
Fix wrong path in tsconfig.app.json

### DIFF
--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -15,7 +15,7 @@
   },
   "include": [
     "src",
-    "src/styled.d.ts"                    
+    "src/styles/styled.d.ts"
   ],
   "exclude": [
     "node_modules",


### PR DESCRIPTION
## Summary
- fix reference to styled-components type definitions

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: ts cannot find React dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6841cf4b1b648329b7d4dfa02b267835