### PR TITLE
Add Jest testing setup and basic tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,9 @@
+export default {
+  preset: 'ts-jest/presets/default-esm',
+  testEnvironment: 'jsdom',
+  setupFilesAfterEnv: ['<rootDir>/src/setupTests.ts'],
+  moduleNameMapper: {
+    '^(\\.{1,2}/.*)\\.js$': '$1',
+  },
+  testMatch: ['**/?(*.)+(test).ts?(x)'],
+};

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "predeploy": "npm run build",
     "deploy": "gh-pages -d build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "jest"
   },
   "dependencies": {
     "react": "^19.1.0",
@@ -30,6 +31,12 @@
     "globals": "^16.0.0",
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.30.1",
-    "vite": "^6.3.5"
+    "vite": "^6.3.5",
+    "@types/jest": "^29.5.10",
+    "jest": "^29.7.0",
+    "jest-environment-jsdom": "^29.7.0",
+    "ts-jest": "^29.1.1",
+    "@testing-library/react": "^14.2.2",
+    "@testing-library/jest-dom": "^6.4.3"
   }
 }

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import App from './App';
+
+describe('App', () => {
+  it('renders the application layout', () => {
+    render(<App />);
+    expect(screen.getByRole('heading', { name: /informações importantes/i })).toBeInTheDocument();
+    expect(screen.getAllByRole('button').length).toBe(2);
+  });
+});

--- a/src/components/DocButton/DocButton.test.tsx
+++ b/src/components/DocButton/DocButton.test.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { DocButton } from './DocButton';
+
+describe('DocButton', () => {
+  it('calls window.open with the given href when clicked', () => {
+    const openSpy = jest.fn();
+    // @ts-ignore
+    window.open = openSpy;
+    render(<DocButton href="https://example.com">Open</DocButton>);
+    fireEvent.click(screen.getByRole('button', { name: /open/i }));
+    expect(openSpy).toHaveBeenCalledWith('https://example.com', '_blank', 'noopener,noreferrer');
+  });
+});

--- a/src/components/Hero/Hero.test.tsx
+++ b/src/components/Hero/Hero.test.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { Hero } from './Hero';
+
+describe('Hero', () => {
+  it('renders scooter image', () => {
+    render(<Hero />);
+    expect(screen.getByAltText(/scooter/i)).toBeInTheDocument();
+  });
+});

--- a/src/components/Specs/Specs.test.tsx
+++ b/src/components/Specs/Specs.test.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { Specs } from './Specs';
+
+describe('Specs', () => {
+  it('renders the list of specifications', () => {
+    render(<Specs />);
+    expect(screen.getByRole('heading', { name: /informações importantes/i })).toBeInTheDocument();
+    expect(screen.getAllByRole('listitem').length).toBeGreaterThan(0);
+  });
+});

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';


### PR DESCRIPTION
## Summary
- set up `jest` with jsdom environment via `jest.config.js`
- add React Testing Library utilities in `setupTests`
- provide initial tests for components and App
- update `package.json` with `test` script and dev dependencies

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a8f8387c48329af328a4e0f7d514c