### PR TITLE
Remove redundant ThemeProvider in App

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,5 @@
 import React, { useState } from 'react'
-import styled, { ThemeProvider } from 'styled-components'
-import { theme } from './styles/theme'
+import styled from 'styled-components'
 import { Hero } from './components/Hero/Hero'
 import { Specs } from './components/Specs/Specs'
 import { DocButton } from './components/DocButton/DocButton'
@@ -31,22 +30,20 @@ export const App: React.FC = () => {
   const addDistance = (km: number) => setTotalKm((prev) => prev + km)
 
   return (
-    <ThemeProvider theme={theme}>
-      <Container>
-        <Hero />
-        <Content>
-          <Odometer totalKm={totalKm} />
-          <TripRecorder onDistance={addDistance} />
-          <Specs />
-          <DocButton href="https://drive.google.com/file/d/149mgLv0_AskqS3bWHQw7kzyudn5YQX5w/view?usp=drive_link">
-            NFe Scooter
-          </DocButton>
-          <DocButton href="https://www.gov.br/transportes/pt-br/assuntos/transito/conteudo-contran/resolucoes/Resolucao9962023.pdf">
-            Resolução Contran Nº 996/2023
-          </DocButton>
-        </Content>
-      </Container>
-    </ThemeProvider>
+    <Container>
+      <Hero />
+      <Content>
+        <Odometer totalKm={totalKm} />
+        <TripRecorder onDistance={addDistance} />
+        <Specs />
+        <DocButton href="https://drive.google.com/file/d/149mgLv0_AskqS3bWHQw7kzyudn5YQX5w/view?usp=drive_link">
+          NFe Scooter
+        </DocButton>
+        <DocButton href="https://www.gov.br/transportes/pt-br/assuntos/transito/conteudo-contran/resolucoes/Resolucao9962023.pdf">
+          Resolução Contran Nº 996/2023
+        </DocButton>
+      </Content>
+    </Container>
   )
 }
 


### PR DESCRIPTION
## Summary
- remove duplicate ThemeProvider usage in App

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685aa6e790988329819fb7e78900263a