### PR TITLE
Fix CORS issue in TripRecorder

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,11 @@ VITE_GOOGLE_MAPS_API_KEY=your-key-here
 
 Make sure the key has the appropriate permissions for Maps JavaScript usage.
 
+> **Note**
+> The Google Maps Directions web service does not enable CORS. The application
+> calculates trip distances using the Maps JavaScript API instead. If you wish to
+> call the web service directly, route the request through a backend or proxy.
+
 ## License
 This project is licensed under the [MIT License](LICENSE).
 

--- a/src/components/Odometer/TripRecorder.tsx
+++ b/src/components/Odometer/TripRecorder.tsx
@@ -1,5 +1,8 @@
 import React, { useState } from 'react'
 
+// Google Maps namespace provided by the script loader
+declare const google: any
+
 interface Coords {
   lat: number
   lng: number
@@ -47,16 +50,39 @@ export const TripRecorder: React.FC<TripRecorderProps> = ({ onDistance }) => {
     }
   }
 
+  /**
+   * Loads the Maps JavaScript API and calculates the distance between two
+   * points using the client-side DirectionsService. The web service version
+   * does not support CORS, so it cannot be called directly from the browser.
+   */
   const fetchDistance = async (orig: Coords, dest: Coords): Promise<number> => {
     const key = import.meta.env.VITE_GOOGLE_MAPS_API_KEY
     if (!key) throw new Error('Google Maps API key missing')
-    const url =
-      `https://maps.googleapis.com/maps/api/directions/json?origin=${orig.lat},${orig.lng}` +
-      `&destination=${dest.lat},${dest.lng}&key=${key}`
-    const res = await fetch(url)
-    const data = await res.json()
-    const meters =
-      data.routes?.[0]?.legs?.[0]?.distance?.value ?? 0
+
+    const loadMaps = (): Promise<typeof google> => {
+      if (window.google) return Promise.resolve(window.google)
+      return new Promise((resolve, reject) => {
+        const script = document.createElement('script')
+        script.src =
+          `https://maps.googleapis.com/maps/api/js?key=${key}&libraries=routes`
+        script.async = true
+        script.onload = () => resolve(window.google)
+        script.onerror = () => reject(new Error('Failed to load Google Maps'))
+        document.head.appendChild(script)
+      })
+    }
+
+    const google = await loadMaps()
+    // load the routes library which provides DirectionsService
+    await google.maps.importLibrary('routes')
+
+    const service = new google.maps.DirectionsService()
+    const { routes } = await service.route({
+      origin: new google.maps.LatLng(orig.lat, orig.lng),
+      destination: new google.maps.LatLng(dest.lat, dest.lng),
+      travelMode: google.maps.TravelMode.DRIVING,
+    })
+    const meters = routes?.[0]?.legs?.[0]?.distance?.value ?? 0
     return meters / 1000
   }
 


### PR DESCRIPTION
## Summary
- switch `TripRecorder` to Google Maps JavaScript API instead of the web service
- document CORS limitation for the directions API

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685aa7265a9c832994cb692aee1548d1