### PR TITLE
Add Google Maps types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,8 @@
         "ts-jest": "^29.1.1",
         "typescript": "~5.8.3",
         "typescript-eslint": "^8.30.1",
-        "vite": "^6.3.5"
+        "vite": "^6.3.5",
+        "@types/google.maps": "^3.57.0"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -2464,6 +2465,13 @@
       "version": "4.2.5",
       "resolved": "https://registry.npmjs.org/@types/stylis/-/stylis-4.2.5.tgz",
       "integrity": "sha512-1Xve+NMN7FWjY14vLoY5tL3BVEQ/n42YLwaqJIPYhotZ9uBHt87VceMwWQpzmdEt2TNXIorIFG+YeCUUW7RInw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/google.maps": {
+      "version": "3.57.0",
+      "resolved": "https://registry.npmjs.org/@types/google.maps/-/google.maps-3.57.0.tgz",
+      "integrity": "",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/tough-cookie": {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "jest-environment-jsdom": "^29.7.0",
     "ts-jest": "^29.1.1",
     "@testing-library/react": "^14.2.2",
-    "@testing-library/jest-dom": "^6.4.3"
+    "@testing-library/jest-dom": "^6.4.3",
+    "@types/google.maps": "^3.57.0"
   }
 }

--- a/src/components/Odometer/TripRecorder.tsx
+++ b/src/components/Odometer/TripRecorder.tsx
@@ -1,8 +1,8 @@
 import React, { useState } from 'react'
 
 // Google Maps namespace will be provided by the script loader and added to
-// the global window object. The explicit interface is declared in
-// `src/vite-env.d.ts` so we can safely reference `window.google`.
+// the global window object. The interface in `src/vite-env.d.ts` declares
+// `google` so we can safely reference `window.google`.
 
 interface Coords {
   lat: number
@@ -60,7 +60,7 @@ export const TripRecorder: React.FC<TripRecorderProps> = ({ onDistance }) => {
     const key = import.meta.env.VITE_GOOGLE_MAPS_API_KEY
     if (!key) throw new Error('Google Maps API key missing')
 
-    type GoogleMaps = typeof window.google
+    type GoogleMaps = typeof google
 
     const loadMaps = (): Promise<GoogleMaps> => {
       if (window.google) return Promise.resolve(window.google)

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -4,5 +4,5 @@
 // once the script finishes loading. Declare the property here so TypeScript is
 // aware of it across the project.
 interface Window {
-  google: any
+  google: typeof google
 }


### PR DESCRIPTION
## Summary
- add `@types/google.maps` dev dependency
- declare `google` type for `window` in `vite-env.d.ts`
- adjust TripRecorder to use `typeof google`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685aee9694948329974b9da10b020db5