### PR TITLE
Remove font import and use link tag

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <link rel="icon" type="image/png" href="/favicon.png" />
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Public+Sans:wght@300;400;600;700&display=swap" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Minha Scooter</title>
 </head>

--- a/src/styles/globalStyle.ts
+++ b/src/styles/globalStyle.ts
@@ -2,17 +2,15 @@
 import { createGlobalStyle } from 'styled-components'
 
 export const GlobalStyle = createGlobalStyle`
-  /* 1) importa a fonte do Google */
-  @import url('https://fonts.googleapis.com/css2?family=Public+Sans:wght@300;400;600;700&display=swap');
 
-  /* 2) reset básico */
+  /* reset básico */
   *, *::before, *::after {
     box-sizing: border-box;
     margin: 0;
     padding: 0;
   }
 
-  /* 3) estilos globais */
+  /* estilos globais */
   body {
     font-family: ${({ theme }) => theme.fonts.primary};
     background: ${({ theme }) => theme.colors.background};


### PR DESCRIPTION
## Summary
- remove `@import` Google Fonts rule from styled-components GlobalStyle
- add Google Fonts link tag to `index.html`
- rely on `font-family` in global styles

## Testing
- `npm test` *(fails: `jest: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685aee994cfc8329b70bd4595fdacf7d